### PR TITLE
remove fixnum warnings

### DIFF
--- a/lib/jimson/client.rb
+++ b/lib/jimson/client.rb
@@ -93,17 +93,17 @@ module Jimson
       return false if data.has_key?('error') && data.has_key?('result')
 
       if data.has_key?('error')
-        if !data['error'].is_a?(Hash) || !data['error'].has_key?('code') || !data['error'].has_key?('message') 
+        if !data['error'].is_a?(Hash) || !data['error'].has_key?('code') || !data['error'].has_key?('message')
           return false
         end
 
-        if !data['error']['code'].is_a?(Fixnum) || !data['error']['message'].is_a?(String)
+        if !data['error']['code'].is_a?(Integer) || !data['error']['message'].is_a?(String)
           return false
         end
       end
 
       return true
-      
+
       rescue
         return false
     end
@@ -116,7 +116,7 @@ module Jimson
     end
 
     def send_batch
-      batch = @batch.map(&:first) # get the requests 
+      batch = @batch.map(&:first) # get the requests
       response = send_batch_request(batch)
 
       begin
@@ -132,14 +132,14 @@ module Jimson
   end
 
   class BatchClient < BlankSlate
-    
+
     def initialize(helper)
       @helper = helper
     end
 
     def method_missing(sym, *args, &block)
       request = Jimson::Request.new(sym.to_s, args)
-      @helper.push_batch_request(request) 
+      @helper.push_batch_request(request)
     end
 
   end
@@ -148,7 +148,7 @@ module Jimson
     reveal :instance_variable_get
     reveal :inspect
     reveal :to_s
-    
+
     def self.batch(client)
       helper = client.instance_variable_get(:@helper)
       batch_client = BatchClient.new(helper)
@@ -162,7 +162,7 @@ module Jimson
     end
 
     def method_missing(sym, *args, &block)
-      @helper.process_call(sym, args) 
+      @helper.process_call(sym, args)
     end
 
     def [](method, *args)
@@ -171,7 +171,7 @@ module Jimson
         new_ns = @namespace.nil? ? "#{method}." : "#@namespace#{method}."
         return Client.new(@url, @opts, new_ns)
       end
-      @helper.process_call(method, args) 
+      @helper.process_call(method, args)
     end
 
   end

--- a/lib/jimson/server.rb
+++ b/lib/jimson/server.rb
@@ -135,7 +135,7 @@ module Jimson
                          'jsonrpc' => [String],
                          'method'  => [String],
                          'params'  => [Hash, Array],
-                         'id'      => [String, Fixnum, Bignum, NilClass]
+                         'id'      => [String, Integer, NilClass]
                        }
 
       return false if !request.is_a?(Hash)


### PR DESCRIPTION
Fixnum and Bignum are deprecated as of 2.4
This removes pesky warnings from Jimson gem.